### PR TITLE
클라이언트 검증 수정

### DIFF
--- a/src/test/java/com/example/customerserver/service/ClientAdministerTest.java
+++ b/src/test/java/com/example/customerserver/service/ClientAdministerTest.java
@@ -8,12 +8,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@Transactional
 class ClientAdministerTest {
 
     @Autowired

--- a/src/test/java/com/example/customerserver/web/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/customerserver/web/controller/AuthControllerTest.java
@@ -33,6 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("AuthController 테스트")
 @SpringBootTest
+@Transactional
 class AuthControllerTest {
 
     private MockMvc mockMvc;
@@ -81,7 +82,13 @@ class AuthControllerTest {
 
         //then
         mockMvc.perform(get("/auth/login")
-                        .header("clientId", clientId)
+                        .param("clientId", clientId)
+                )
+                .andExpect(status().is3xxRedirection())
+                .andDo(print());
+
+        mockMvc.perform(get("/auth/login")
+                        .sessionAttr("clientId", clientId)
                 )
                 .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.view().name("signin"))
@@ -89,6 +96,7 @@ class AuthControllerTest {
                 .andDo(print());
 
     }
+
 
     @Test
     @DisplayName("[GET [/auth/code] code 와 함께 redirect 테스트")
@@ -127,8 +135,7 @@ class AuthControllerTest {
 
         //then
         mockMvc.perform(post("/auth/gettoken")
-                        .header("Authorization", code)
-                        .header("clientId", clientId))
+                        .header("Authorization", code))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.accessToken").exists())
                 .andDo(print());
@@ -145,8 +152,7 @@ class AuthControllerTest {
 
         //then
         mockMvc.perform(post("/auth/gettoken")
-                        .header("Authorization", code)
-                        .header("clientId", clientId))
+                        .header("Authorization", code))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(AppConfig.getHost() + "/error/code"));
 

--- a/src/test/java/com/example/customerserver/web/controller/ClientControllerTest.java
+++ b/src/test/java/com/example/customerserver/web/controller/ClientControllerTest.java
@@ -25,6 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("Client TEST")
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc
 class ClientControllerTest {
 
@@ -41,6 +42,8 @@ class ClientControllerTest {
     @DisplayName("[POST] [/client/register] Client 등록 테스트")
     public void registerClientTest() throws Exception {
 
+        long previous = clientRepository.count();
+
         mockMvc.perform(post("/client/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new ClientRequest("service-hub", "https://service-hub.org"))))
@@ -49,7 +52,7 @@ class ClientControllerTest {
                 .andDo(MockMvcResultHandlers.print());
 
         assertThat(clientRepository.count())
-                .isEqualTo(1);
+                .isEqualTo(previous + 1);
     }
 
     @Test

--- a/src/test/java/com/example/customerserver/web/controller/CustomerControllerTest.java
+++ b/src/test/java/com/example/customerserver/web/controller/CustomerControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -20,6 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc
 class CustomerControllerTest {
 
@@ -58,7 +60,6 @@ class CustomerControllerTest {
 
         mockMvc.perform(post("/api/v1/customer")
                         .header("Authorization", "Bearer " + accessToken)
-                        .header("clientId", clientId)
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(id))
@@ -75,7 +76,6 @@ class CustomerControllerTest {
         String clientId = clientSteps.clientRegisterWithDefaultStep();
 
         mockMvc.perform(post("/api/v1/customer")
-                        .header("clientId", clientId)
                 )
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.codeName").value("C002"))
@@ -95,7 +95,6 @@ class CustomerControllerTest {
 
         mockMvc.perform(post("/api/v1/customer")
                         .header("Authorization", "Bearer " + accessToken)
-                        .header("clientId", clientId)
                 )
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.codeName").value("C003"))

--- a/src/test/java/com/example/customerserver/web/controller/SignupTest.java
+++ b/src/test/java/com/example/customerserver/web/controller/SignupTest.java
@@ -11,10 +11,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
+@Transactional
 @SpringBootTest
 @AutoConfigureMockMvc
 public class SignupTest {
@@ -40,7 +42,11 @@ public class SignupTest {
         String clientId = clientSteps.clientRegisterWithDefaultStep();
 
         mockMvc.perform(get("/signup")
-                        .header("clientId", clientId))
+                        .param("clientId", clientId))
+                .andExpect(MockMvcResultMatchers.status().is3xxRedirection());
+
+        mockMvc.perform(get("/signup")
+                        .sessionAttr("clientId", clientId))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.model().attributeExists("signupRequest"))
                 .andExpect(MockMvcResultMatchers.view().name("signup"))


### PR DESCRIPTION
[원인] client 입장에서 header 에 clientId를 넣고 리다이렉트하기가 쉽지 않다.
[해결] 로그인과 회원가입에는 쿼리파라미터를 통해 clientId를 받는다.
[과정] 쿼리파라미터를 통해 clientId를 전달받되 다시 세션에 clientId를 설정하고 리다이렉트를 수행하여 URL에 노출되지 않도록한다.
[변경] 코드와 엑세스 토큰으로 검증하는 앤드포인트에는 clientId 검증을 수행하지 않는다.

closes #20 